### PR TITLE
fix postcell view

### DIFF
--- a/Roomblr/Post.swift
+++ b/Roomblr/Post.swift
@@ -48,6 +48,14 @@ class Post: NSObject {
                     photoRatio =  (width / height) as! Double
                 }
             }
+            
+            if photoUrl == nil {
+                var photo = altSizes[0]
+                var width = photo["width"] as! Double
+                var height = photo["height"] as! Double
+                photoUrl = photo["url"] as! String
+                photoRatio =  (width / height) as! Double
+            }
         } else if type == "text" {
             body = dic["body"] as! String
         }

--- a/Roomblr/PostCell.swift
+++ b/Roomblr/PostCell.swift
@@ -37,6 +37,8 @@ class PostCell: UITableViewCell {
                 }
             } else if post?.type == "text" {
                 postBodyLabel.text = post!.body
+                photoView.alpha = 0.0
+                postBodyLabel.alpha = 1.0
             }
             
             // retreive blog avatarURL

--- a/Roomblr/TumblrClient.swift
+++ b/Roomblr/TumblrClient.swift
@@ -120,7 +120,9 @@ class TumblrClient: BDBOAuth1RequestOperationManager {
                 var i = 0
                 for (i; i < postsResponse.count; i++ ) {
                     var post = Post(dic: postsResponse[i] as! NSDictionary)
-                    posts.append(post)
+                    if post.type == "text" || post.type == "photo" {
+                        posts.append(post)
+                    }
                 }
                 completion(posts: posts, error: nil)
             


### PR DESCRIPTION
## What?

This PR fixed when there is no 250 width photo provided for a photo post from Tumblr API, we should still choose a photo to use.

This also filters out only text and photo posts, leaving out other types posts.
